### PR TITLE
add interfaces for each connection impl that have covariant return types...

### DIFF
--- a/heroku-api-integration-tests/src/test/java/com/heroku/api/AsyncHttpClientModule.java
+++ b/heroku-api-integration-tests/src/test/java/com/heroku/api/AsyncHttpClientModule.java
@@ -2,13 +2,14 @@ package com.heroku.api;
 
 import com.google.inject.Provides;
 import com.heroku.api.connection.AsyncHttpClientConnection;
+import com.heroku.api.connection.ListenableFutureConnection;
 import com.heroku.api.exception.RequestFailedException;
 
 import java.io.IOException;
 
 public class AsyncHttpClientModule extends ConnectionTestModule {
     @Provides()
-    AsyncHttpClientConnection getConnectionImpl() throws IOException {
+    ListenableFutureConnection getConnectionImpl() throws IOException {
         try {
             return new AsyncHttpClientConnection();
         } catch (RequestFailedException e) {

--- a/heroku-api-integration-tests/src/test/java/com/heroku/api/FinagleModule.java
+++ b/heroku-api-integration-tests/src/test/java/com/heroku/api/FinagleModule.java
@@ -2,14 +2,16 @@ package com.heroku.api;
 
 import com.google.inject.Provides;
 import com.heroku.api.connection.FinagleConnection;
+import com.heroku.api.connection.TwitterFutureConnection;
 import com.heroku.api.exception.RequestFailedException;
+import javassist.convert.TransformWriteField;
 
 import java.io.IOException;
 
 public class FinagleModule extends ConnectionTestModule {
 
     @Provides
-    FinagleConnection getConnectionImpl() throws IOException {
+    TwitterFutureConnection getConnectionImpl() throws IOException {
 
         try {
             return FinagleConnection.apply();

--- a/heroku-api-integration-tests/src/test/java/com/heroku/api/HttpClientModule.java
+++ b/heroku-api-integration-tests/src/test/java/com/heroku/api/HttpClientModule.java
@@ -1,6 +1,7 @@
 package com.heroku.api;
 
 import com.google.inject.Provides;
+import com.heroku.api.connection.FutureConnection;
 import com.heroku.api.connection.HttpClientConnection;
 import com.heroku.api.exception.RequestFailedException;
 import com.heroku.api.parser.JsonSelector;
@@ -26,7 +27,7 @@ public class HttpClientModule extends ConnectionTestModule {
     }
 
     @Provides()
-    HttpClientConnection getConnectionImpl() throws IOException {
+    FutureConnection getConnectionImpl() throws IOException {
         try {
             return new HttpClientConnection();
         } catch (RequestFailedException e) {

--- a/heroku-api-integration-tests/src/test/java/com/heroku/api/PlayModule.java
+++ b/heroku-api-integration-tests/src/test/java/com/heroku/api/PlayModule.java
@@ -1,6 +1,7 @@
 package com.heroku.api;
 
 import com.google.inject.Provides;
+import com.heroku.api.connection.PlayConnection;
 import com.heroku.api.connection.PlayWSConnection;
 import com.heroku.api.exception.RequestFailedException;
 
@@ -11,7 +12,7 @@ import static com.heroku.api.IntegrationTestConfig.CONFIG;
 public class PlayModule extends ConnectionTestModule {
 
     @Provides
-    PlayWSConnection getConnectionImpl() throws IOException {
+    PlayConnection getConnectionImpl() throws IOException {
 
         try {
             IntegrationTestConfig.TestUser testUser = CONFIG.getDefaultUser();

--- a/heroku-http-apache/src/main/java/com/heroku/api/connection/FutureConnection.java
+++ b/heroku-http-apache/src/main/java/com/heroku/api/connection/FutureConnection.java
@@ -1,0 +1,14 @@
+package com.heroku.api.connection;
+
+import com.heroku.api.request.Request;
+
+import java.util.concurrent.Future;
+
+
+public interface FutureConnection extends AsyncConnection<Future<?>> {
+    @Override
+    <T> Future<T> executeAsync(Request<T> request, String apiKey);
+
+    @Override
+    <T> T execute(Request<T> request, String apiKey);
+}

--- a/heroku-http-apache/src/main/java/com/heroku/api/connection/HttpClientConnection.java
+++ b/heroku-http-apache/src/main/java/com/heroku/api/connection/HttpClientConnection.java
@@ -32,7 +32,7 @@ import java.util.concurrent.*;
 
 import static com.heroku.api.Heroku.Config.ENDPOINT;
 
-public class HttpClientConnection implements AsyncConnection<Future<?>> {
+public class HttpClientConnection implements FutureConnection {
 
 
     private URL endpoint = HttpUtil.toURL(ENDPOINT.value);
@@ -74,8 +74,8 @@ public class HttpClientConnection implements AsyncConnection<Future<?>> {
             }
 
             httpClient.getCredentialsProvider().setCredentials(
-                new AuthScope(endpoint.getHost(), endpoint.getPort()),
-                new UsernamePasswordCredentials("", key)
+                    new AuthScope(endpoint.getHost(), endpoint.getPort()),
+                    new UsernamePasswordCredentials("", key)
             );
 
             BasicHttpContext ctx = new BasicHttpContext();
@@ -165,11 +165,11 @@ public class HttpClientConnection implements AsyncConnection<Future<?>> {
             if (authState.getAuthScheme() == null) {
                 AuthScheme authScheme = (AuthScheme) context.getAttribute("preemptive-auth");
                 CredentialsProvider credsProvider = (CredentialsProvider) context.getAttribute(
-                    ClientContext.CREDS_PROVIDER);
+                        ClientContext.CREDS_PROVIDER);
                 HttpHost targetHost = (HttpHost) context.getAttribute(ExecutionContext.HTTP_TARGET_HOST);
                 if (authScheme != null) {
                     Credentials creds = credsProvider.getCredentials(
-                        new AuthScope(targetHost.getHostName(), targetHost.getPort()));
+                            new AuthScope(targetHost.getHostName(), targetHost.getPort()));
                     if (creds == null) {
                         throw new HttpException("No credentials for preemptive authentication");
                     }

--- a/heroku-http-finagle/src/main/scala/com/heroku/api/connection/FinagleConnection.scala
+++ b/heroku-http-finagle/src/main/scala/com/heroku/api/connection/FinagleConnection.scala
@@ -18,8 +18,14 @@ import com.heroku.api.Heroku
 import com.twitter.util.{Base64StringEncoder, Future}
 import com.twitter.conversions.time._
 
+trait TwitterFutureConnection extends AsyncConnection[Future[_]] {
+  def executeAsync[T](request: Request[T], apiKey: String): Future[T]
 
-class FinagleConnection extends AsyncConnection[Future[_]] {
+  def execute[T](request: Request[T], apiKey: String): T
+}
+
+
+class FinagleConnection extends TwitterFutureConnection {
 
   type HttpService = Service[HttpRequest, HttpResponse]
   val timeout = 60.seconds

--- a/heroku-http-ning-async/src/main/java/com/heroku/api/connection/AsyncHttpClientConnection.java
+++ b/heroku-http-ning-async/src/main/java/com/heroku/api/connection/AsyncHttpClientConnection.java
@@ -16,7 +16,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 
-public class AsyncHttpClientConnection implements AsyncConnection<ListenableFuture<?>> {
+
+
+public class AsyncHttpClientConnection implements ListenableFutureConnection {
 
     private AsyncHttpClient httpClient = getHttpClient();
 

--- a/heroku-http-ning-async/src/main/java/com/heroku/api/connection/ListenableFutureConnection.java
+++ b/heroku-http-ning-async/src/main/java/com/heroku/api/connection/ListenableFutureConnection.java
@@ -1,0 +1,14 @@
+package com.heroku.api.connection;
+
+import com.heroku.api.request.Request;
+import com.ning.http.client.ListenableFuture;
+
+
+public interface ListenableFutureConnection extends AsyncConnection<ListenableFuture<?>> {
+
+    @Override
+    <T> ListenableFuture<T> executeAsync(Request<T> request, String apiKey);
+
+    @Override
+    <T> T execute(Request<T> request, String apiKey);
+}

--- a/heroku-http-play/src/main/scala/com/heroku/api/connection/PlayWSConnection.scala
+++ b/heroku-http-play/src/main/scala/com/heroku/api/connection/PlayWSConnection.scala
@@ -9,8 +9,13 @@ import com.ning.http.client.Realm
 import com.heroku.api.request.Request
 import java.util.concurrent.TimeUnit
 
+trait PlayConnection extends AsyncConnection[Promise[_]] {
+  def executeAsync[T](request: Request[T], apiKey: String): Promise[T]
 
-class PlayWSConnection extends AsyncConnection[Promise[_]] {
+  def execute[T](request: Request[T], apiKey: String): T
+}
+
+class PlayWSConnection extends PlayConnection {
 
   def executeAsync[T](request: Request[T], key: String): Promise[T] = {
     val host = Heroku.Config.ENDPOINT.value;


### PR DESCRIPTION
... that return Future<T> instead of Future<?> to make mocking/testing of code that uses these more straightforward

This lets you do something like

class MyService {

```
  public PlayConnection conn;  
```

}

and then wire it up in prod with PlayWSConnection or in test with a mocked out impl of PlayConnection
