### PR TITLE
app clone with specified name

### DIFF
--- a/heroku-api/src/main/java/com/heroku/api/HerokuAPI.java
+++ b/heroku-api/src/main/java/com/heroku/api/HerokuAPI.java
@@ -3,7 +3,6 @@ package com.heroku.api;
 
 import com.heroku.api.connection.Connection;
 import com.heroku.api.connection.ConnectionFactory;
-import com.heroku.api.request.app.AppClone;
 import com.heroku.api.request.addon.AddonInstall;
 import com.heroku.api.request.addon.AddonList;
 import com.heroku.api.request.addon.AddonRemove;
@@ -170,7 +169,21 @@ public class HerokuAPI {
      * @return details about the cloned app
      */
     public App cloneApp(String templateAppName) {
-        return connection.execute(new AppClone(templateAppName), apiKey);
+        return connection.execute(new AppClone(templateAppName, new App()), apiKey);
+    }
+
+    /**
+     * Clone an existing app that has previously been designated as a template
+     * into the authenticated user's account with details specified in the target app.
+     * Currently, only specifying the name of the target app is supported.
+     * App cloning is only supported on the {@link Heroku.Stack.Cedar} stack.
+     *
+     * @param templateAppName Name of the template app to clone.
+     * @param targetApp Details about the target app.
+     * @return details about the cloned targetApp
+     */
+    public App cloneApp(String templateAppName, App targetApp) {
+        return connection.execute(new AppClone(templateAppName, targetApp), apiKey);
     }
     
     /**

--- a/heroku-api/src/main/java/com/heroku/api/request/app/AppClone.java
+++ b/heroku-api/src/main/java/com/heroku/api/request/app/AppClone.java
@@ -4,6 +4,7 @@ import com.heroku.api.App;
 import com.heroku.api.Heroku;
 import com.heroku.api.exception.RequestFailedException;
 import com.heroku.api.http.Http;
+import com.heroku.api.http.HttpUtil;
 import com.heroku.api.request.Request;
 import com.heroku.api.request.RequestConfig;
 
@@ -19,8 +20,11 @@ public class AppClone implements Request<App> {
 
     private final RequestConfig config;
     
-    public AppClone(String appName) {
-        config = new RequestConfig().with(Heroku.RequestKey.AppName, appName);
+    public AppClone(String templateAppName, App targetApp) {
+        RequestConfig builder = new RequestConfig();
+        builder = builder.with(Heroku.RequestKey.AppName, templateAppName);
+        builder = (targetApp.getName() != null) ? builder.with(Heroku.RequestKey.CreateAppName, targetApp.getName()) : builder;
+        config = builder;
     }
 
     @Override
@@ -35,12 +39,12 @@ public class AppClone implements Request<App> {
 
     @Override
     public boolean hasBody() {
-        return false;
+        return true;
     }
 
     @Override
     public String getBody() {
-        throw new UnsupportedOperationException();
+        return HttpUtil.encodeParameters(config, Heroku.RequestKey.CreateAppName);
     }
 
     @Override


### PR DESCRIPTION
This change is for #47 to allow the target app name to be specified at the time of clone.
I followed the same pattern as AppCreate with an App object being passed in instead of specifying the app name directly to allow for future flexibility.
