### PR TITLE
Prepare for central to include scaladoc as jar

### DIFF
--- a/heroku-http-finagle/pom.xml
+++ b/heroku-http-finagle/pom.xml
@@ -64,10 +64,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <version>2.15.2</version>
-
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>

--- a/heroku-http-play/pom.xml
+++ b/heroku-http-play/pom.xml
@@ -40,10 +40,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <version>2.15.2</version>
-
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.2.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -186,6 +191,19 @@
                                 <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-scaladoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>doc-jar</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
Now that scala artifacts are going to Central, javadoc needs to be included. This supported is in the updated `scala-maven-plugin` (previously `maven-scala-plugin`) under the `doc-jar` goal. This is under the `net.alchim31.maven` groupId (instead of `org.scala-tools`), so wanted to send as a pull request since not if its ok to use this. @sclasen, thoughts?
