### PR TITLE
Deserialize Large Integers

### DIFF
--- a/heroku-api-integration-tests/src/test/java/com/heroku/api/parser/JsonParseTest.java
+++ b/heroku-api-integration-tests/src/test/java/com/heroku/api/parser/JsonParseTest.java
@@ -9,7 +9,6 @@ import org.testng.annotations.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
-import java.math.BigInteger;
 import java.util.List;
 
 import static com.heroku.api.parser.Json.parse;
@@ -72,8 +71,8 @@ public class JsonParseTest {
       String appJson = "{\"repo_size\":2177925120,\"slug_size\":2177925120}";
 
       final App app = parser.parse(appJson.getBytes("UTF-8"), App.class);
-      Assert.assertEquals(app.getRepoSize(), new BigInteger("2177925120"));
-      Assert.assertEquals(app.getSlugSize(), new BigInteger("2177925120"));
+      Assert.assertEquals(app.getRepoSize(), 2177925120L);
+      Assert.assertEquals(app.getSlugSize(), 2177925120L);
     }
 
     @Test(expectedExceptions = ParseException.class)

--- a/heroku-api-integration-tests/src/test/java/com/heroku/api/parser/JsonParseTest.java
+++ b/heroku-api-integration-tests/src/test/java/com/heroku/api/parser/JsonParseTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
+import java.math.BigInteger;
 import java.util.List;
 
 import static com.heroku.api.parser.Json.parse;
@@ -65,7 +66,16 @@ public class JsonParseTest {
         final App appList = parser.parse(unknownProperty.getBytes("UTF-8"), App.class);
         Assert.assertNull(appList.getName());
     }
-    
+
+    @Test(dataProvider = "getParsers")
+    public void bigIntShouldParseLargeRepoSizes(Parser parser) throws UnsupportedEncodingException {
+      String appJson = "{\"repo_size\":2177925120,\"slug_size\":2177925120}";
+
+      final App app = parser.parse(appJson.getBytes("UTF-8"), App.class);
+      Assert.assertEquals(app.getRepoSize(), new BigInteger("2177925120"));
+      Assert.assertEquals(app.getSlugSize(), new BigInteger("2177925120"));
+    }
+
     @Test(expectedExceptions = ParseException.class)
     public void nullRequestTypeShouldThrowParseException() {
         parse(new byte[]{}, null);

--- a/heroku-api/src/main/java/com/heroku/api/Addon.java
+++ b/heroku-api/src/main/java/com/heroku/api/Addon.java
@@ -1,7 +1,6 @@
 package com.heroku.api;
 
 import java.io.Serializable;
-import java.math.BigInteger;
 import java.net.URL;
 
 /**
@@ -18,7 +17,7 @@ public class Addon implements Serializable {
     URL url;
     String state;
     String beta;
-    BigInteger price_cents;
+    long price_cents;
     String price_unit;
     String id;
     Boolean configured;
@@ -31,11 +30,11 @@ public class Addon implements Serializable {
         this.configured = configured;
     }
 
-    public BigInteger getPriceCents() {
+    public long getPriceCents() {
         return price_cents;
     }
 
-    private void setPrice_cents(BigInteger price_cents) {
+    private void setPrice_cents(long price_cents) {
         this.price_cents = price_cents;
     }
 

--- a/heroku-api/src/main/java/com/heroku/api/Addon.java
+++ b/heroku-api/src/main/java/com/heroku/api/Addon.java
@@ -1,6 +1,7 @@
 package com.heroku.api;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.net.URL;
 
 /**
@@ -17,7 +18,7 @@ public class Addon implements Serializable {
     URL url;
     String state;
     String beta;
-    int price_cents;
+    BigInteger price_cents;
     String price_unit;
     String id;
     Boolean configured;
@@ -30,11 +31,11 @@ public class Addon implements Serializable {
         this.configured = configured;
     }
 
-    public int getPriceCents() {
+    public BigInteger getPriceCents() {
         return price_cents;
     }
 
-    private void setPrice_cents(int price_cents) {
+    private void setPrice_cents(BigInteger price_cents) {
         this.price_cents = price_cents;
     }
 

--- a/heroku-api/src/main/java/com/heroku/api/App.java
+++ b/heroku-api/src/main/java/com/heroku/api/App.java
@@ -1,7 +1,6 @@
 package com.heroku.api;
 
 import java.io.Serializable;
-import java.math.BigInteger;
 
 /**
  * Data model for a Heroku App. Also serves as a builder class when making requests to create an app.
@@ -25,8 +24,8 @@ public class App implements Serializable {
     String git_url;
     String buildpack_provided_description;
     String released_at;
-    BigInteger slug_size;
-	  BigInteger repo_size;
+    long slug_size;
+	  long repo_size;
     int dynos;
 	  int workers;
 
@@ -100,11 +99,11 @@ public class App implements Serializable {
         this.buildpack_provided_description = buildpack_provided_description;
     }
 
-    private void setSlug_size(BigInteger slug_size) {
+    private void setSlug_size(long slug_size) {
         this.slug_size = slug_size;
     }
 
-    private void setRepo_size(BigInteger repo_size) {
+    private void setRepo_size(long repo_size) {
         this.repo_size = repo_size;
     }
 
@@ -167,11 +166,11 @@ public class App implements Serializable {
         return repo_migrate_status;
     }
 
-    public BigInteger getSlugSize() {
+    public long getSlugSize() {
         return slug_size;
     }
 
-    public BigInteger getRepoSize() {
+    public long getRepoSize() {
         return repo_size;
     }
 

--- a/heroku-api/src/main/java/com/heroku/api/App.java
+++ b/heroku-api/src/main/java/com/heroku/api/App.java
@@ -25,9 +25,9 @@ public class App implements Serializable {
     String buildpack_provided_description;
     String released_at;
     long slug_size;
-	  long repo_size;
+    long repo_size;
     int dynos;
-	  int workers;
+    int workers;
 
     /**
      * Builder method for specifying the name of an app.

--- a/heroku-api/src/main/java/com/heroku/api/App.java
+++ b/heroku-api/src/main/java/com/heroku/api/App.java
@@ -1,6 +1,7 @@
 package com.heroku.api;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 
 /**
  * Data model for a Heroku App. Also serves as a builder class when making requests to create an app.
@@ -24,10 +25,10 @@ public class App implements Serializable {
     String git_url;
     String buildpack_provided_description;
     String released_at;
-    int slug_size;
-	int repo_size;
+    BigInteger slug_size;
+	  BigInteger repo_size;
     int dynos;
-	int workers;
+	  int workers;
 
     /**
      * Builder method for specifying the name of an app.
@@ -99,11 +100,11 @@ public class App implements Serializable {
         this.buildpack_provided_description = buildpack_provided_description;
     }
 
-    private void setSlug_size(int slug_size) {
+    private void setSlug_size(BigInteger slug_size) {
         this.slug_size = slug_size;
     }
 
-    private void setRepo_size(int repo_size) {
+    private void setRepo_size(BigInteger repo_size) {
         this.repo_size = repo_size;
     }
 
@@ -166,11 +167,11 @@ public class App implements Serializable {
         return repo_migrate_status;
     }
 
-    public int getSlugSize() {
+    public BigInteger getSlugSize() {
         return slug_size;
     }
 
-    public int getRepoSize() {
+    public BigInteger getRepoSize() {
         return repo_size;
     }
 

--- a/heroku-api/src/main/java/com/heroku/api/Proc.java
+++ b/heroku-api/src/main/java/com/heroku/api/Proc.java
@@ -1,7 +1,6 @@
 package com.heroku.api;
 
 import java.io.Serializable;
-import java.math.BigInteger;
 import java.net.URI;
 
 /**
@@ -23,7 +22,7 @@ public class Proc implements Serializable {
     String state;
     String pretty_state;
     String transitioned_at;
-    BigInteger elapsed;
+    long elapsed;
     boolean attached;
     URI rendezvous_url;
 
@@ -107,11 +106,11 @@ public class Proc implements Serializable {
         this.transitioned_at = transitioned_at;
     }
 
-    public BigInteger getElapsed() {
+    public long getElapsed() {
         return elapsed;
     }
 
-    private void setElapsed(BigInteger elapsed) {
+    private void setElapsed(long elapsed) {
         this.elapsed = elapsed;
     }
 

--- a/heroku-api/src/main/java/com/heroku/api/Proc.java
+++ b/heroku-api/src/main/java/com/heroku/api/Proc.java
@@ -1,6 +1,7 @@
 package com.heroku.api;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.net.URI;
 
 /**
@@ -22,7 +23,7 @@ public class Proc implements Serializable {
     String state;
     String pretty_state;
     String transitioned_at;
-    int elapsed;
+    BigInteger elapsed;
     boolean attached;
     URI rendezvous_url;
 
@@ -106,11 +107,11 @@ public class Proc implements Serializable {
         this.transitioned_at = transitioned_at;
     }
 
-    public int getElapsed() {
+    public BigInteger getElapsed() {
         return elapsed;
     }
 
-    private void setElapsed(int elapsed) {
+    private void setElapsed(BigInteger elapsed) {
         this.elapsed = elapsed;
     }
 


### PR DESCRIPTION
In some edge cases, large integers are returned by the API. This is a
breaking change that migrates int values to BigInteger values.

@sclasen @ryanbrainard how do you feel about this breaking change? This addresses heroku/cisaurus#69.