### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk11
   - openjdk8
-  - openjdk11
 env:
   global:
   - secure: 4F3gN34XI1iFEkqPY2+bVNUqaw4M2DoeJncOsxQ1YxwCDqs/ploKXcuf9RJ8irjayHw/BUOJQSgGyj0JadxLfgI55rQqSSL5R9OdVChJHNb4I0hUjbDNpb0Fn5m33LYOYKL9OfoGGGojgo8QKYcWTylGRyehPjZFE/f309SQWSg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: java
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+jdk:
+  - oraclejdk8
+  - oraclejdk11
+  - openjdk8
+  - openjdk11
 env:
   global:
   - secure: 4F3gN34XI1iFEkqPY2+bVNUqaw4M2DoeJncOsxQ1YxwCDqs/ploKXcuf9RJ8irjayHw/BUOJQSgGyj0JadxLfgI55rQqSSL5R9OdVChJHNb4I0hUjbDNpb0Fn5m33LYOYKL9OfoGGGojgo8QKYcWTylGRyehPjZFE/f309SQWSg=


### PR DESCRIPTION
As discussed in #88, Oracle JDK8 is no longer supported in travis (> trusty). I replaced it with `openjdk8` and it now builds again.

I also wanted to add oracle as well as openjdk11 to the build matrix, but ran into issues. I opened #89 to track that issue separately.