### PR TITLE
Fix scaladoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
                     <configuration>
                         <args>
                             <arg>-nobootcp</arg>
+                            <arg>-usejavacp</arg>
                         </args>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>


### PR DESCRIPTION
Fixes scaladoc generation which prevented releases of `heroku.jar`. Also adds an explicit version for maven-surefire-plugin version to silence rightful warnings about unstable builds.